### PR TITLE
fix: sender not eoa on Monad testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/gas-estimations
 
+## 0.2.66
+
+### Patch Changes
+
+- Set sender for estimateGas to undefined for Monad only, use EP address for other chains
+
 ## 0.2.65
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/gas-estimations",
-  "version": "0.2.65",
+  "version": "0.2.66",
   "repository": "https://github.com/bcnmy/entry-point-gas-estimations",
   "author": "Nikola Divić <nikola.divic@biconomy.io>",
   "license": "MIT",

--- a/src/gas-estimator/evm/EVMGasEstimator.ts
+++ b/src/gas-estimator/evm/EVMGasEstimator.ts
@@ -249,6 +249,10 @@ export class EVMGasEstimator implements GasEstimator {
         // use the actual user operation to estimate the preVerificationGas, because it depends on maxFeePerGas
         this.estimatePreVerificationGas(userOperation, baseFeePerGas),
         this.rpcClient.estimateGas({
+          // for monad testnet, we don't set the sender address so it doesn't throw 'sender must be an eoa'
+          account: [10143].includes(this.chain.chainId)
+            ? undefined
+            : entryPoint.address,
           to: userOperation.sender,
           data: userOperation.callData
         })


### PR DESCRIPTION
- Set sender to `undefined` when estimating call gas limit for Monad only.
- Initially (in the previous PR) I set it like that for all networks but it causes some weird behavior on Base Sepolia (on probably on other chains, but not observed yet)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `@biconomy/gas-estimations` package to version `0.2.66`, with specific changes to how the gas estimation process handles the `sender` address for the Monad testnet.

### Detailed summary
- Updated version in `package.json` from `0.2.65` to `0.2.66`.
- Added a note in `CHANGELOG.md` about setting the `sender` for `estimateGas` to `undefined` for Monad, while using the `EP` address for other chains.
- Modified `EVMGasEstimator.ts` to conditionally set the `account` based on the chain ID.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->