### PR TITLE
revert: monad estimate call gas limit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/gas-estimations
 
+## 0.2.68
+
+### Patch Changes
+
+- Revert the callGasLimit change for Monad now that their RPCs behave in the same way as other RPCs
+
 ## 0.2.67
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/gas-estimations",
-  "version": "0.2.67",
+  "version": "0.2.68",
   "repository": "https://github.com/bcnmy/entry-point-gas-estimations",
   "author": "Nikola Divić <nikola.divic@biconomy.io>",
   "license": "MIT",

--- a/src/gas-estimator/evm/EVMGasEstimator.ts
+++ b/src/gas-estimator/evm/EVMGasEstimator.ts
@@ -246,7 +246,6 @@ export class EVMGasEstimator implements GasEstimator {
       await Promise.all([
         entryPoint.simulateHandleOp({
           userOperation: constantGasFeeUserOperation,
-          // userOperation,
           targetAddress: options.entryPointAddress,
           targetCallData: "0x",
           stateOverrides
@@ -254,10 +253,7 @@ export class EVMGasEstimator implements GasEstimator {
         // use the actual user operation to estimate the preVerificationGas, because it depends on maxFeePerGas
         this.estimatePreVerificationGas(userOperation, baseFeePerGas),
         this.rpcClient.estimateGas({
-          // for monad testnet, we don't set the sender address so it doesn't throw 'sender must be an eoa'
-          account: [10143].includes(this.chain.chainId)
-            ? undefined
-            : entryPoint.address,
+          account: entryPoint.address,
           to: userOperation.sender,
           data: userOperation.callData
         })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the package `@biconomy/gas-estimations` from `0.2.67` to `0.2.68`, reverts a previous change related to `callGasLimit` for `Monad`, and modifies the `account` parameter in the `estimateGas` method within the `EVMGasEstimator` class.

### Detailed summary
- Updated version in `package.json` to `0.2.68`.
- Added a new entry in `CHANGELOG.md` for version `0.2.68`.
- Reverted the `callGasLimit` change for `Monad` in `CHANGELOG.md`.
- Changed `account` parameter from a conditional check to `entryPoint.address` in `EVMGasEstimator.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->