### PR TITLE
fix: simulate handle op arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/gas-estimations
 
+## 0.2.69
+
+### Patch Changes
+
+- Fix arguments for simulateHandleOp
+
 ## 0.2.68
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/gas-estimations",
-  "version": "0.2.68",
+  "version": "0.2.69",
   "repository": "https://github.com/bcnmy/entry-point-gas-estimations",
   "author": "Nikola Divić <nikola.divic@biconomy.io>",
   "license": "MIT",

--- a/src/entrypoint/v0.6.0/EntryPointV6.test.ts
+++ b/src/entrypoint/v0.6.0/EntryPointV6.test.ts
@@ -138,7 +138,7 @@ describe("e2e", () => {
             try {
               await epv6.simulateHandleOp({
                 userOperation,
-                targetAddress: epv6.address,
+                targetAddress: userOperation.sender,
                 targetCallData: userOperation.callData
               })
             } catch (err: any) {
@@ -162,7 +162,7 @@ describe("e2e", () => {
 
               const executionResult = await epv6.simulateHandleOp({
                 userOperation,
-                targetAddress: epv6.address,
+                targetAddress: userOperation.sender,
                 targetCallData: userOperation.callData,
                 stateOverrides
               })
@@ -193,7 +193,7 @@ describe("e2e", () => {
                   initCode,
                   nonce
                 },
-                targetAddress: epv6.address,
+                targetAddress: userOperation.sender,
                 targetCallData: userOperation.callData,
                 stateOverrides: new StateOverrideBuilder()
                   .overrideBalance(sender, parseEther("10"))
@@ -243,7 +243,7 @@ describe("e2e", () => {
                     ...userOperation,
                     paymasterAndData
                   },
-                  targetAddress: epv6.address,
+                  targetAddress: userOperation.sender,
                   targetCallData: userOperation.callData,
                   stateOverrides
                 })
@@ -277,7 +277,7 @@ describe("e2e", () => {
                     ...userOperation,
                     paymasterAndData
                   },
-                  targetAddress: epv6.address,
+                  targetAddress: userOperation.sender,
                   targetCallData: userOperation.callData,
                   stateOverrides
                 })

--- a/src/entrypoint/v0.7.0/EntryPointV7Simulations.test.ts
+++ b/src/entrypoint/v0.7.0/EntryPointV7Simulations.test.ts
@@ -139,8 +139,8 @@ describe("e2e", () => {
               it("should return an ExecutionResult greater than 0", async () => {
                 const result = await epV7Simulations.simulateHandleOp({
                   userOperation,
-                  targetAddress: zeroAddress,
-                  targetCallData: "0x",
+                  targetAddress: userOperation.sender,
+                  targetCallData: userOperation.callData,
                   stateOverrides
                 })
 
@@ -188,8 +188,8 @@ describe("e2e", () => {
 
                   const result = await epV7Simulations.simulateHandleOp({
                     userOperation: sponsoredUserOperation,
-                    targetAddress: zeroAddress,
-                    targetCallData: "0x",
+                    targetAddress: userOperation.sender,
+                    targetCallData: userOperation.callData,
                     stateOverrides
                   })
 
@@ -238,8 +238,8 @@ describe("e2e", () => {
 
                 const result = await epV7Simulations.simulateHandleOp({
                   userOperation: sponsoredUserOperation,
-                  targetAddress: zeroAddress,
-                  targetCallData: "0x",
+                  targetAddress: userOperation.sender,
+                  targetCallData: userOperation.callData,
                   stateOverrides
                 })
 

--- a/src/gas-estimator/evm/EVMGasEstimator.ts
+++ b/src/gas-estimator/evm/EVMGasEstimator.ts
@@ -246,8 +246,8 @@ export class EVMGasEstimator implements GasEstimator {
       await Promise.all([
         entryPoint.simulateHandleOp({
           userOperation: constantGasFeeUserOperation,
-          targetAddress: options.entryPointAddress,
-          targetCallData: "0x",
+          targetAddress: userOperation.sender,
+          targetCallData: userOperation.callData,
           stateOverrides
         }),
         // use the actual user operation to estimate the preVerificationGas, because it depends on maxFeePerGas
@@ -342,8 +342,8 @@ export class EVMGasEstimator implements GasEstimator {
     const [executionResult, preVerificationGas] = await Promise.all([
       entryPoint.simulateHandleOp({
         userOperation: constantGasFeeUserOperation,
-        targetAddress: options.entryPointAddress,
-        targetCallData: "0x",
+        targetAddress: userOperation.sender,
+        targetCallData: userOperation.callData,
         stateOverrides
       }),
       this.estimatePreVerificationGas(userOperation, baseFeePerGas)


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `@biconomy/gas-estimations` package to version `0.2.69`, fixing the arguments passed to the `simulateHandleOp` function across various files to use `userOperation.sender` and `userOperation.callData` instead of hardcoded values.

### Detailed summary
- Updated `CHANGELOG.md` for version `0.2.69` with a patch change note.
- Changed `version` in `package.json` from `0.2.68` to `0.2.69`.
- Modified `src/gas-estimator/evm/EVMGasEstimator.ts` to use `userOperation.sender` and `userOperation.callData` in `simulateHandleOp`.
- Updated `src/entrypoint/v0.7.0/EntryPointV7Simulations.test.ts` to reflect the same changes in `simulateHandleOp`.
- Adjusted `src/entrypoint/v0.6.0/EntryPointV6.test.ts` to use `userOperation.sender` and `userOperation.callData` in multiple instances of `simulateHandleOp`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->