### PR TITLE
fix: base & op pm addys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/gas-estimations
 
+## 0.2.70
+
+### Patch Changes
+
+- Fixed paymaster addresses for Base & Optimism.
+
 ## 0.2.69
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/gas-estimations",
-  "version": "0.2.69",
+  "version": "0.2.70",
   "repository": "https://github.com/bcnmy/entry-point-gas-estimations",
   "author": "Nikola Divić <nikola.divic@biconomy.io>",
   "license": "MIT",

--- a/src/chains/chains.ts
+++ b/src/chains/chains.ts
@@ -18,6 +18,11 @@ const DEFAULT_ENTRYPOINT_V7_TOKEN_PAYMASTER_ADDRESS =
 const DEFAULT_ENTRYPOINT_V7_TOKEN_PAYMASTER_DEPOSITS_STATE_KEY =
   "0xca2edac642186a7c1820b405da08488d91db4bdbbbd4e0b687d2f4f822a383c5"
 
+const BASE_OPTIMISM_V7_SPONSORSHIP_PAYMASTER_ADDRESS =
+  "0x0000006087310897e0BFfcb3f0Ed3704f7146852";
+const BASE_OPTIMISM_V7_TOKEN_PAYMASTER_ADDRESS =
+  "0x00000000301515A5410e0d768aF4f53c416edf19";
+
 const DEFAULT_ENTRYPOINT_V7_DEPOSITS_STATE = {
   [DEFAULT_ENTRYPOINT_V7_SPONSORSHIP_PAYMASTER_ADDRESS]: {
     stateKey: DEFAULT_ENTRYPOINT_V7_SPONSORSHIP_PAYMASTER_DEPOSITS_STATE_KEY
@@ -66,6 +71,20 @@ const DEFAULT_ENTRYPOINT_V7_PAYMASTERS = {
     postOpGasLimit: 50000n
   },
   [DEFAULT_ENTRYPOINT_V7_TOKEN_PAYMASTER_ADDRESS]: {
+    type: "token",
+    dummyPaymasterData:
+      DEFAULT_ENTRYPOINT_V7_TOKEN_PAYMASTER_DUMMY_PAYMASTER_DATA,
+    postOpGasLimit: 95000n
+  }
+}
+
+const BASE_OPTIMISM_ENTRYPOINT_V7_PAYMASTERS = {
+  [BASE_OPTIMISM_V7_SPONSORSHIP_PAYMASTER_ADDRESS]: {
+    type: "sponsorship",
+    dummyPaymasterData: DEFAULT_EP_V7_SPONSORSHIP_DUMMY_PAYMASTER_DATA,
+    postOpGasLimit: 50000n
+  },
+  [BASE_OPTIMISM_V7_TOKEN_PAYMASTER_ADDRESS]: {
     type: "token",
     dummyPaymasterData:
       DEFAULT_ENTRYPOINT_V7_TOKEN_PAYMASTER_DUMMY_PAYMASTER_DATA,
@@ -305,7 +324,10 @@ export const supportedChains: Record<string, SupportedChain> = {
       nexus: true
     },
     entryPoints: DEFAULT_ENTRYPOINTS,
-    paymasters: DEFAULT_PAYMASTERS
+    paymasters: {
+      v060: DEFAULT_ENTRYPOINT_V6_PAYMASTERS,
+      v070: BASE_OPTIMISM_ENTRYPOINT_V7_PAYMASTERS
+    }
   },
   "11155420": {
     chainId: 11155420,
@@ -323,7 +345,10 @@ export const supportedChains: Record<string, SupportedChain> = {
       nexus: true
     },
     entryPoints: DEFAULT_ENTRYPOINTS,
-    paymasters: DEFAULT_PAYMASTERS
+    paymasters: {
+      v060: DEFAULT_ENTRYPOINT_V6_PAYMASTERS,
+      v070: BASE_OPTIMISM_ENTRYPOINT_V7_PAYMASTERS
+    }
   },
   "43114": {
     chainId: 43114,
@@ -379,7 +404,10 @@ export const supportedChains: Record<string, SupportedChain> = {
       nexus: true
     },
     entryPoints: DEFAULT_ENTRYPOINTS,
-    paymasters: DEFAULT_PAYMASTERS
+    paymasters: {
+      v060: DEFAULT_ENTRYPOINT_V6_PAYMASTERS,
+      v070: BASE_OPTIMISM_ENTRYPOINT_V7_PAYMASTERS
+    }
   },
   "84532": {
     chainId: 84532,
@@ -397,7 +425,10 @@ export const supportedChains: Record<string, SupportedChain> = {
       nexus: true
     },
     entryPoints: DEFAULT_ENTRYPOINTS,
-    paymasters: DEFAULT_PAYMASTERS
+    paymasters: {
+      v060: DEFAULT_ENTRYPOINT_V6_PAYMASTERS,
+      v070: BASE_OPTIMISM_ENTRYPOINT_V7_PAYMASTERS
+    }
   },
   "59144": {
     chainId: 59144,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the version of the `@biconomy/gas-estimations` package to `0.2.70`, includes fixes for paymaster addresses, and introduces new paymaster configurations for `Base` and `Optimism`.

### Detailed summary
- Updated version in `package.json` from `0.2.69` to `0.2.70`.
- Added new paymaster addresses for `Base` and `Optimism`.
- Introduced `BASE_OPTIMISM_ENTRYPOINT_V7_PAYMASTERS` with sponsorship and token types.
- Updated `supportedChains` to reference new paymaster configurations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->